### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Once [installed](#install), you can use the following code to run an interactive
 bash shell and issue some commands within:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$launcher = new ProcessLauncher($loop);
+$launcher = new Clue\React\Shell\ProcessLauncher();
 
 $shell = $launcher->createDeferredShell('bash');
 
@@ -27,8 +26,6 @@ $shell->execute('env | sort | head -n10')->then(function ($env) {
 });
 
 $shell->end();
-
-$loop->run();
 ```
 
 See also the [examples](examples):

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/child-process": "^0.5 || ^0.4 || ^0.3",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6",
+        "react/child-process": "^0.6.3",
+        "react/event-loop": "^1.2",
+        "react/stream": "^1.2",
         "react/promise": "^2.0 || ^1.0"
     },
     "require-dev": {

--- a/examples/bash.php
+++ b/examples/bash.php
@@ -1,12 +1,10 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Shell\ProcessLauncher;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$launcher = new ProcessLauncher($loop);
+$launcher = new ProcessLauncher();
 
 $shell = $launcher->createDeferredShell('bash 2>&1');
 
@@ -19,5 +17,3 @@ $shell->execute('env | sort | head -n10')->then(function ($env) {
 });
 
 $shell->end();
-
-$loop->run();

--- a/examples/docker.php
+++ b/examples/docker.php
@@ -1,12 +1,10 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Shell\ProcessLauncher;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$launcher = new ProcessLauncher($loop);
+$launcher = new ProcessLauncher();
 
 $shell = $launcher->createDeferredShell('docker run -i --rm debian bash');
 
@@ -19,5 +17,3 @@ $shell->execute('env')->then(function ($env) {
 });
 
 $shell->end();
-
-$loop->run();

--- a/examples/php.php
+++ b/examples/php.php
@@ -1,12 +1,10 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Shell\ProcessLauncher;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$launcher = new ProcessLauncher($loop);
+$launcher = new ProcessLauncher();
 
 $shell = $launcher->createDeferredShell('php -a');
 $shell->setBounding("echo '{{ bounding }}';");
@@ -24,5 +22,3 @@ CODE
 });
 
 $shell->end();
-
-$loop->run();

--- a/src/ProcessLauncher.php
+++ b/src/ProcessLauncher.php
@@ -3,17 +3,28 @@
 namespace Clue\React\Shell;
 
 use React\ChildProcess\Process;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use Clue\React\Shell\DeferredShell;
 use React\Stream\CompositeStream;
 
 class ProcessLauncher
 {
+    /** @var LoopInterface */
     private $loop;
 
-    public function __construct(LoopInterface $loop)
+    /**
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
+     * @param ?LoopInterface $loop
+     */
+    public function __construct(LoopInterface $loop = null)
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
     }
 
     /**

--- a/tests/ProcessLauncherTest.php
+++ b/tests/ProcessLauncherTest.php
@@ -18,6 +18,17 @@ class ProcessLauncherTest extends TestCase
         $this->processLauncher = new ProcessLauncher($this->loop);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $launcher = new ProcessLauncher();
+
+        $ref = new \ReflectionProperty($launcher, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($launcher);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testProcessWillBeStarted()
     {
         $process = $this->getMockBuilder('React\ChildProcess\Process')->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$launcher = new Clue\React\Shell\ProcessLauncher($loop);

// new (using default loop)
$launcher = new Clue\React\Shell\ProcessLauncher();
```
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229, reactphp/event-loop#232, reactphp/child-process#87 and reactphp/stream#159